### PR TITLE
why is www a noun? get rid of that

### DIFF
--- a/nouns_nix.txt
+++ b/nouns_nix.txt
@@ -33086,7 +33086,6 @@ WTC
 WTO
 WTV
 WV
-WWW
 WY
 Wabash
 Wabash River


### PR DESCRIPTION
i mean honestly, it makes it match urls