### PR TITLE
Sleep function fix

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -87,11 +87,13 @@ module.exports = async (config, client, influx, message) => {
             files: ['https://cdn.discordapp.com/attachments/437302483044401152/446047008147374091/Roblox_Death_Sound_Effect.mp3']
         })
         if (message.member.voiceChannelID) {
+            console.log('Connecting to voice channel')
             message.member.voiceChannel.join()
                 .then(connection => {
                     connection.playFile('./Roblox_Death_Sound_Effect.mp3')
                 })
             await sleep(30000)
+            console.log('disconnecting from voice channel')
             message.member.voiceChannel.leave()
         }
     }

--- a/events/message.js
+++ b/events/message.js
@@ -364,5 +364,7 @@ function urlGenerator (msgObj) {
 }
 
 async function sleep (ms = 0) {
-    return new Promise(resolve => setTimeout(null, ms))
+    return new Promise((resolve, reject) => {
+        setTimeout(null, ms)
+    })
 }

--- a/events/message.js
+++ b/events/message.js
@@ -367,6 +367,8 @@ function urlGenerator (msgObj) {
 
 async function sleep (ms = 0) {
     return new Promise((resolve, reject) => {
-        setTimeout(resolve(), 3000)
+        setTimeout(() => {
+            resolve()
+        }, ms)
     })
 }

--- a/events/message.js
+++ b/events/message.js
@@ -365,6 +365,6 @@ function urlGenerator (msgObj) {
 
 async function sleep (ms = 0) {
     return new Promise((resolve, reject) => {
-        setTimeout(() => { return 0 }, ms)
+        setTimeout(resolve(), ms)
     })
 }

--- a/events/message.js
+++ b/events/message.js
@@ -93,7 +93,7 @@ module.exports = async (config, client, influx, message) => {
                     connection.playFile('./Roblox_Death_Sound_Effect.mp3')
                 })
             await sleep(30000)
-            console.log('disconnecting from voice channel')
+            console.log('Disconnecting from voice channel')
             message.member.voiceChannel.leave()
         }
     }
@@ -367,6 +367,6 @@ function urlGenerator (msgObj) {
 
 async function sleep (ms = 0) {
     return new Promise((resolve, reject) => {
-        setTimeout(resolve(), ms)
+        setTimeout(resolve(), 3000)
     })
 }

--- a/events/message.js
+++ b/events/message.js
@@ -365,6 +365,6 @@ function urlGenerator (msgObj) {
 
 async function sleep (ms = 0) {
     return new Promise((resolve, reject) => {
-        setTimeout(null, ms)
+        setTimeout(() => { return 0 }, ms)
     })
 }

--- a/events/message.js
+++ b/events/message.js
@@ -92,7 +92,7 @@ module.exports = async (config, client, influx, message) => {
                 .then(connection => {
                     connection.playFile('./Roblox_Death_Sound_Effect.mp3')
                 })
-            await sleep(30000)
+            await sleep(3000)
             console.log('Disconnecting from voice channel')
             message.member.voiceChannel.leave()
         }

--- a/events/message.js
+++ b/events/message.js
@@ -91,7 +91,7 @@ module.exports = async (config, client, influx, message) => {
                 .then(connection => {
                     connection.playFile('./Roblox_Death_Sound_Effect.mp3')
                 })
-            await sleep(3000)
+            await sleep(30000)
             message.member.voiceChannel.leave()
         }
     }


### PR DESCRIPTION
This fixes the bug that was causing issue GH-26.

The `sleep` function within `nixbot/events/message.js` was throwing the following error:
`(node:28586) UnhandledPromiseRejectionWarning: TypeError: "callback" argument must be a function`

This was being caused by the `Promise` wrapper within the `sleep` function not having it's `resolve` argument be used as a function within the `Promise.

I thought I had solved that in f47b724 as I was no longer getting errors, but instead it was returning too quickly and causing a fatal error due to the bot joining and leaving the voice channel within milliseconds.

Instead I found that I needed to wrap `resolve()` within an anonymous function so that it didn't get triggered instantly.

After testing on Nixbot-dev, I can confirm that everything now works as intended.

Thank god for the MDN.